### PR TITLE
Fix `Dllist.promote` for the first entry in the list

### DIFF
--- a/src/dllist.ml
+++ b/src/dllist.ml
@@ -63,12 +63,14 @@ let append t v =
   (t.first, removed)
 
 let promote t i =
-  if t.prev.(i) <> -1 then t.next.(t.prev.(i)) <- t.next.(i);
-  if t.next.(i) <> -1 then t.prev.(t.next.(i)) <- t.prev.(i);
-  t.prev.(t.first) <- i;
-  t.next.(i) <- t.first;
-  t.prev.(i) <- -1;
-  t.first <- i;
+  if t.prev.(i) <> -1 then (
+    (* The element at index [i] is not already at the head of the list *)
+    t.next.(t.prev.(i)) <- t.next.(i);
+    if t.next.(i) <> -1 then t.prev.(t.next.(i)) <- t.prev.(i);
+    t.prev.(t.first) <- i;
+    t.next.(i) <- t.first;
+    t.prev.(i) <- -1;
+    t.first <- i);
   t.first
 
 let remove t i =

--- a/src/dllist.ml
+++ b/src/dllist.ml
@@ -63,7 +63,7 @@ let append t v =
   (t.first, removed)
 
 let promote t i =
-  if t.prev.(i) <> -1 then (
+  if i <> t.first then (
     (* The element at index [i] is not already at the head of the list *)
     t.next.(t.prev.(i)) <- t.next.(i);
     if t.next.(i) <> -1 then t.prev.(t.next.(i)) <- t.prev.(i);


### PR DESCRIPTION
The previous implementation of `Dllist.promote` breaks the invariants of the data-structure when attempting to promote the first element. This commit fixes it to do nothing in this case.

This seems to make the test in https://github.com/pascutto/cachecache/pull/1 pass.